### PR TITLE
Delete all bugs

### DIFF
--- a/lib/jobba/status.rb
+++ b/lib/jobba/status.rb
@@ -36,7 +36,7 @@ module Jobba
     end
 
     def self.local_attrs
-      %w(id state progress errors data kill_requested_at job_name job_args attempt) +
+      %w(id state progress errors data kill_requested_at job_name job_args attempt prior_attempts) +
       State::ALL.collect(&:timestamp_name)
     end
 
@@ -162,7 +162,7 @@ module Jobba
     end
 
     def prior_attempts
-      [*0..attempt-1].collect{|ii| self.class.find!("#{id}:#{ii}")}
+      @prior_attempts ||= [*0..attempt-1].collect{|ii| self.class.find!("#{id}:#{ii}")}
     end
 
     protected
@@ -319,6 +319,7 @@ module Jobba
       end
 
       prior_attempts.each(&:delete!)
+      @prior_attempts = nil
     end
 
     def delete_locally!

--- a/lib/jobba/statuses.rb
+++ b/lib/jobba/statuses.rb
@@ -33,6 +33,10 @@ class Jobba::Statuses
 
   def delete_all!
     load
+
+    # preload prior attempts because loading them is not `multi`-friendly
+    @cache.each(&:prior_attempts)
+
     redis.multi do
       @cache.each(&:delete!)
     end

--- a/lib/jobba/statuses.rb
+++ b/lib/jobba/statuses.rb
@@ -25,10 +25,10 @@ class Jobba::Statuses
     if any?(&:incomplete?)
       raise(Jobba::NotCompletedError,
             "This status cannot be deleted because it isn't complete.  Use " \
-            "`delete!` if you want to delete anyway.")
+            "`delete_all!` if you want to delete anyway.")
     end
 
-    delete!
+    delete_all!
   end
 
   def delete_all!

--- a/spec/status_spec.rb
+++ b/spec/status_spec.rb
@@ -369,8 +369,9 @@ describe Jobba::Status do
 
       it 'deletes prior attempts when current status deleted' do
         prior_0, prior_1 = @status.prior_attempts
+        prior_0_id = prior_0.id
         @status.delete!
-        expect(Jobba::Status.find(prior_0.id)).to be_nil
+        expect(Jobba::Status.find(prior_0_id)).to be_nil
       end
     end
 

--- a/spec/statuses_spec.rb
+++ b/spec/statuses_spec.rb
@@ -76,6 +76,12 @@ describe Jobba::Statuses do
       expect(statuses.count).to eq 3
     end
 
+    it 'does delete_all when there are no incompletes' do
+      queued.delete!
+      described_class.new(failed.id, succeeded.id).delete_all
+      expect(Jobba.redis.keys("*").count).to eq 0
+    end
+
     it 'does delete_all! when there are some incomplete' do
       expect{statuses.delete_all!}.to_not raise_error
       expect(statuses.count).to eq 0

--- a/spec/statuses_spec.rb
+++ b/spec/statuses_spec.rb
@@ -82,6 +82,12 @@ describe Jobba::Statuses do
       expect(statuses.to_a).to eq []
       expect(Jobba.redis.keys("*").count).to eq 0
     end
+
+    it 'can delete_all! when there are restarted jobs' do
+      failed.started! # restart
+      statuses.delete_all!
+      expect(Jobba.redis.keys("*").count).to eq 0
+    end
   end
 
   it 'can bulk request kill' do


### PR DESCRIPTION
* Fixes a bug where `delete_all!` blew up when any of the jobs being deleted had been restarted.
* Fixes a bug where `delete_all` was calling a method that didn't exist.  D'oh!