### PR TITLE
faster performance for single clauses & pagination

### DIFF
--- a/README.md
+++ b/README.md
@@ -439,6 +439,17 @@ Jobba.where(...).run.count   # These pull data back to Ruby and count in Ruby
 Jobba.where(...).run.empty?
 ```
 
+## Pagination
+
+Pagination is supported with an ActiveRecord-like interface.  You can call `.limit(x)` and `.offset(y)` on
+queries, e.g.
+
+```ruby
+Jobba.where(state: :succeeded).limit(10).offset(20).to_a
+```
+
+Specifying a limit does not guarantee that you'll get that many elements back, as there may not be that many left in the result.
+
 ## Notes
 
 ### Times
@@ -448,6 +459,8 @@ Note that, in operations having to do with time, this gem ignores anything beyon
 ### Efficiency
 
 Jobba strives to do all of its operations as efficiently as possible using built-in Redis operations.  If you find a place where the efficiency can be improved, please submit an issue or a pull request.
+
+Single-clause queries (those with one `where` call) have been optimized.  `Jobba.all` is a single-clause query.  If you have lots of IDs, try to get by with single-clause queries.  Multi-clause queries (including `count`) have to copy sets into temporary working sets where query clauses are ANDed together.  This can be expensive for large datasets.
 
 ### Write from one; Read from many
 
@@ -462,6 +475,12 @@ $> USE_REAL_REDIS=true rspec
 ```
 
 Travis runs the specs with both `fakeredis` and real Redis.
+
+Clauses need to implement three methods:
+
+1. `to_new_set` - puts the IDs indicated by the clause into a new sorted set in redis
+2. `result_ids` - used to get the IDs indicated by the clause when the clause is the only one in the query
+3. `result_count` - used to get the count of IDs indicated by the clause when the clause is the only one in the query
 
 ## TODO
 

--- a/lib/jobba.rb
+++ b/lib/jobba.rb
@@ -38,4 +38,12 @@ module Jobba
     )
   end
 
+  # Clears the whole shebang!  USE WITH CARE!
+  def self.clear_all_jobba_data!
+    keys = Jobba.redis.keys("*")
+    keys.each_slice(1000) do |some_keys|
+      Jobba.redis.del(*some_keys)
+    end
+  end
+
 end

--- a/lib/jobba/clause.rb
+++ b/lib/jobba/clause.rb
@@ -1,16 +1,22 @@
 class Jobba::Clause
-  attr_reader :keys, :min, :max
+  attr_reader :keys, :min, :max, :offset, :limit
 
   include Jobba::Common
 
   # if `keys` or `suffixes` is an array, all entries will be included in the resulting set
-  def initialize(prefix: nil, suffixes: nil, keys: nil, min: nil, max: nil)
+  def initialize(prefix: nil, suffixes: nil, keys: nil, min: nil, max: nil,
+                 offset: nil, limit: nil, keys_contain_only_unique_ids: false)
+
     if keys.nil? && prefix.nil? && suffixes.nil?
       raise ArgumentError, "Either `keys` or both `prefix` and `suffix` must be specified.", caller
     end
 
     if (prefix.nil? && !suffixes.nil?) || (!prefix.nil? && suffixes.nil?)
       raise ArgumentError, "When `prefix` is given, so must `suffix` be, and vice versa.", caller
+    end
+
+    if (offset.nil? && !limit.nil?) || (!offset.nil? && limit.nil?)
+      raise ArgumentError, "When `offset` is given, so must `limit` be, and vice versa.", caller
     end
 
     if keys
@@ -22,6 +28,11 @@ class Jobba::Clause
 
     @min = min
     @max = max
+
+    @offset = offset
+    @limit = limit
+
+    @keys_contain_only_unique_ids = keys_contain_only_unique_ids
   end
 
   def to_new_set
@@ -39,6 +50,75 @@ class Jobba::Clause
     end
 
     new_key
+  end
+
+  def result_ids
+    # If we have one key and it is sorted, we can let redis return limited IDs,
+    # so handle that case specially.
+
+    if @keys.one?
+      ids = get_members(key: @keys.first, use_limit_if_sorted_set: true)
+    else
+      ids = @keys.flat_map do |key|
+        get_members(key: key, use_limit_if_sorted_set: false)
+      end
+
+      ids.sort!
+      ids.uniq! unless @keys_contain_only_unique_ids
+    end
+
+    # This may repeat limiting done by redis, but no biggie
+    if !@offset.nil? && !@limit.nil?
+      ids.slice(@offset, @limit)
+    else
+      ids
+    end
+  end
+
+  def get_members(key:, use_limit_if_sorted_set: false)
+    if sorted_key?(key)
+      min = @min.nil? ? "-inf" : "(#{@min}"
+      max = @max.nil? ? "+inf" : "(#{@max}"
+
+      options = {}
+      options[:limit] = [@offset, @limit] if use_limit_if_sorted_set && !@offset.nil? && !@limit.nil?
+
+      ids = redis.zrangebyscore(key, min, max, options)
+    else
+      ids = redis.smembers(key)
+      ids.sort!
+    end
+
+    ids
+  end
+
+  def result_count
+    if @keys.one? || @keys_contain_only_unique_ids
+      # can count each key on its own using fast redis ops and add them up
+      unlimited_count = @keys.map do |key|
+        if sorted_key?(key)
+          if @min.nil? && @max.nil?
+            redis.zcard(key)
+          else
+            min = @min.nil? ? "-inf" : "(#{@min}"
+            max = @max.nil? ? "+inf" : "(#{@max}"
+
+            redis.zcount(key, min, max)
+          end
+        else
+          redis.scard(key)
+        end
+      end.reduce(:+)
+
+      [unlimited_count, @limit].compact.min
+    else
+      # Because we need to get a count of uniq members, have to do a full query
+      result_ids.count
+    end
+  end
+
+  def sorted_key?(key)
+    key.match(/_at$/)
   end
 
 end

--- a/lib/jobba/clause.rb
+++ b/lib/jobba/clause.rb
@@ -1,5 +1,5 @@
 class Jobba::Clause
-  attr_reader :keys, :min, :max, :offset, :limit
+  attr_reader :keys, :min, :max
 
   include Jobba::Common
 

--- a/lib/jobba/clause.rb
+++ b/lib/jobba/clause.rb
@@ -74,8 +74,8 @@ class Jobba::Clause
 
   def get_members(key:, offset: nil, limit: nil)
     if sorted_key?(key)
-      min = @min.nil? ? "-inf" : "(#{@min}"
-      max = @max.nil? ? "+inf" : "(#{@max}"
+      min = @min.nil? ? "-inf" : "#{@min}"
+      max = @max.nil? ? "+inf" : "#{@max}"
 
       options = {}
       is_limited = false
@@ -103,8 +103,8 @@ class Jobba::Clause
           if @min.nil? && @max.nil?
             redis.zcard(key)
           else
-            min = @min.nil? ? "-inf" : "(#{@min}"
-            max = @max.nil? ? "+inf" : "(#{@max}"
+            min = @min.nil? ? "-inf" : "#{@min}"
+            max = @max.nil? ? "+inf" : "#{@max}"
 
             redis.zcount(key, min, max)
           end

--- a/lib/jobba/clause_factory.rb
+++ b/lib/jobba/clause_factory.rb
@@ -65,7 +65,10 @@ class Jobba::ClauseFactory
     }.uniq
 
     validate_state_name!(state)
-    Jobba::Clause.new(keys: state)
+
+    # An ID is in only one state at a time, so we can tell `Clause` that
+    # info via `keys_contain_only_unique_ids` -- helps it be more efficient
+    Jobba::Clause.new(keys: state, keys_contain_only_unique_ids: true)
   end
 
   def self.validate_state_name!(state_name)

--- a/lib/jobba/id_clause.rb
+++ b/lib/jobba/id_clause.rb
@@ -11,4 +11,12 @@ class Jobba::IdClause
     redis.zadd(new_key, @ids.collect{|id| [0, id]}) if @ids.any?
     new_key
   end
+
+  def result_ids
+    @ids.map(&:to_s)
+  end
+
+  def result_count
+    @ids.count
+  end
 end

--- a/lib/jobba/id_clause.rb
+++ b/lib/jobba/id_clause.rb
@@ -13,10 +13,10 @@ class Jobba::IdClause
   end
 
   def result_ids(offset: nil, limit: nil)
-    @ids.map(&:to_s)
+    @ids.map(&:to_s).slice(offset || 0, limit || @ids.count)
   end
 
   def result_count(offset: nil, limit: nil)
-    @ids.count
+    Jobba::Utils.limited_count(nonlimited_count: @ids.count, offset: offset, limit: limit)
   end
 end

--- a/lib/jobba/id_clause.rb
+++ b/lib/jobba/id_clause.rb
@@ -12,11 +12,11 @@ class Jobba::IdClause
     new_key
   end
 
-  def result_ids
+  def result_ids(offset: nil, limit: nil)
     @ids.map(&:to_s)
   end
 
-  def result_count
+  def result_count(offset: nil, limit: nil)
     @ids.count
   end
 end

--- a/lib/jobba/query.rb
+++ b/lib/jobba/query.rb
@@ -6,6 +6,8 @@ class Jobba::Query
 
   include Jobba::Common
 
+  attr_reader :_limit, :_offset
+
   def where(options)
     options.each do |kk,vv|
       clauses.push(Jobba::ClauseFactory.new_clause(kk,vv))
@@ -14,8 +16,19 @@ class Jobba::Query
     self
   end
 
+  def limit(number)
+    @limit = number
+    @offset ||= 0
+    self
+  end
+
+  def offset(number)
+    @offset = number
+    self
+  end
+
   def count
-    _run(COUNT_STATUSES)
+    _run(CountStatuses.new(self))
   end
 
   def empty?
@@ -39,7 +52,7 @@ class Jobba::Query
   end
 
   def run
-    _run(GET_STATUSES)
+    _run(GetStatuses.new(self))
   end
 
   protected
@@ -50,44 +63,106 @@ class Jobba::Query
     @clauses = []
   end
 
-  class RunBlocks
-    attr_reader :multi_clause_block, :output_block, :single_clause_block
+  # class RunBlocks
+  #   attr_reader :multi_clause_block, :output_block, :single_clause_block
 
-    def initialize(single_clause_block:, multi_clause_block:, output_block: nil)
-      @single_clause_block = single_clause_block
-      @multi_clause_block = multi_clause_block
-      @output_block = output_block || ->(input) { input }
+  #   def initialize(single_clause_block:, multi_clause_block:, output_block: nil)
+  #     @single_clause_block = single_clause_block
+  #     @multi_clause_block = multi_clause_block
+  #     @output_block = output_block || ->(input) { input }
+  #   end
+  # end
+
+  # GET_STATUSES = RunBlocks.new(
+  #   single_clause_block: ->(clause, options={}) {
+  #     clause.result_ids(limit: options[:limit], offset: options[:offset])
+  #   },
+  #   multi_clause_block: ->(working_set, redis, options={}) {
+  #     start = options[:offset] || 0
+  #     stop = options[:limit].nil? ? -1 : start + options[:limit]
+  #     redis.zrange(working_set, start, stop)
+  #   },
+  #   output_block: ->(ids) {
+  #     Jobba::Statuses.new(ids)
+  #   }
+  # )
+
+  # COUNT_STATUSES = RunBlocks.new(
+  #   single_clause_block: ->(clause, options={}) {
+  #     clause.result_count(limit: options[:limit], offset: options[:offset])
+  #   },
+  #   multi_clause_block: ->(working_set, redis, options={}) {
+  #     redis.zcard(working_set)
+  #   }
+  #   output_block: ->(nonlimited_count, options={}) {
+  #     start = options[:offset] || 0
+  #     stop = [(options[:limit] || count), count].min
+  #     stop - start
+  #   }
+  # )
+
+  class Operations
+    attr_reader :query, :redis
+
+    def initialize(query)
+      @query = query
+      @redis = query.redis
+    end
+
+    def handle_single_clause(clause)
+      raise "AbstractMethod"
+    end
+
+    def handle_result_set(result_set)
+      raise "AbstractMethod"
+    end
+
+    def postprocess_output(output)
+      output
     end
   end
 
-  GET_STATUSES = RunBlocks.new(
-    single_clause_block: ->(clause) {
-      clause.result_ids # becomes `clause.result_ids` and `output_block` used on this too
-    },
-    multi_clause_block: ->(working_set, redis) {
-      redis.zrange(working_set, 0, -1)
-    },
-    output_block: ->(ids) {
+  class GetStatuses < Operations
+    def handle_single_clause(clause)
+      clause.result_ids(limit: query._limit, offset: query._offset)
+    end
+
+    def handle_result_set(result_set)
+      start = query._offset || 0
+      stop = query._limit.nil? ? -1 : start + query._limit
+      redis.zrange(result_set, start, stop)
+    end
+
+    def postprocess_output(ids)
       Jobba::Statuses.new(ids)
-    }
-  )
+    end
+  end
 
-  COUNT_STATUSES = RunBlocks.new(
-    single_clause_block: ->(clause) {
-      clause.result_count
-    },
-    multi_clause_block: ->(working_set, redis) {
-      redis.zcard(working_set)
-    }
-  )
+  class CountStatuses < Operations
+    def handle_single_clause(clause)
+      clause.result_count(limit: query._limit, offset: query._offset)
+    end
 
-  def _run(run_blocks)
+    def handle_result_set(result_set)
+      redis.zcard(result_set)
+    end
+
+    def postprocess_output(nonlimited_count)
+      Jobba::Utils.limited_count(nonlimited_count: nonlimited_count, offset: query._offset, limit: query._limit)
+    end
+  end
+
+  def _run(operations)
+    if _limit.nil? && !_offset.nil?
+      raise ArgumentError, "`limit` must be set if `offset` is set", caller
+    end
+
     load_default_clause if clauses.empty?
 
     if clauses.one?
       # We can make specialized calls that don't need intermediate copies of sets
       # to be made (which are costly)
-      clause_output = run_blocks.single_clause_block.call(clauses.first)
+      clause_output = operations.handle_single_clause(clauses.first)
     else
       # Each clause in a query is converted to a sorted set (which may be filtered,
       # e.g. in the case of timestamp clauses) and then the sets are successively
@@ -118,7 +193,7 @@ class Jobba::Query
         end
 
         # This is later accessed as `multi_result[-2]` since it is the second to last output
-        run_blocks.multi_clause_block.call(working_set, redis)
+        operations.handle_result_set(working_set)
 
         redis.del(working_set)
       end
@@ -126,7 +201,7 @@ class Jobba::Query
       clause_output = multi_result[-2]
     end
 
-    run_blocks.output_block.call(clause_output)
+    operations.postprocess_output(clause_output)
   end
 
   def load_default_clause

--- a/lib/jobba/utils.rb
+++ b/lib/jobba/utils.rb
@@ -26,4 +26,45 @@ module Jobba::Utils
     "temp:#{SecureRandom.hex(10)}"
   end
 
+  def self.limited_count(nonlimited_count:, offset:, limit:)
+    raise(ArgumentError, "`limit` cannot be negative") if !limit.nil? && limit < 0
+    raise(ArgumentError, "`offset` cannot be negative") if !offset.nil? && offset < 0
+
+    # If we get a count of an array or set that doesn't take into account
+    # specified offsets and limits (what we call a `nonlimited_count`, but
+    # we need the count to effectively have been done with an offset and
+    # limit, this method calculates that limited count.
+    #
+    # This can happen when it is more efficient to calculate an unlimited
+    # count and then limit it after the fact.
+    #
+    # E.g.
+    #
+    # Get count of
+    #   array = [a b c d e f g]
+    # where
+    #   offset = 4
+    #   limit = 5
+    #
+    # nonlimited_count = 7
+    #
+    # The limited array includes the highlighted (^) elements
+    #   array = [a b c d e f g]
+    #                    ^ ^ ^ ^ ^
+    # Element `e` is the first element indicated by an offset of 4.  The
+    # limit of 5 then causes us to take the rest of the elements in the array.
+    # The limit here is effectively 3 since there are only 3 elements left.
+    #
+    # So the limited_count is 3.
+
+    first_position_counted = offset || 0
+
+    # The `min` here is to make sure we don't go beyond the end of the array.  The `- 1`
+    # is because we are getting a zero-indexed position from a count.
+    last_position_counted = [first_position_counted + (limit || nonlimited_count), nonlimited_count].min - 1
+
+    # Guard against first position being after last position by forcing min of 0
+    [last_position_counted - first_position_counted + 1, 0].max
+  end
+
 end

--- a/spec/clause_spec.rb
+++ b/spec/clause_spec.rb
@@ -1,0 +1,78 @@
+require 'spec_helper'
+
+describe Jobba::Clause do
+
+  context '#get_members' do
+    context 'sorted set' do
+      before(:each) { Jobba.redis.zadd("blah_at", [[1, "a"], [2, "b"], [3, "c"], [4, "d"]]) }
+
+      it 'filters by min only' do
+        expect(described_class.new(keys: "blah_at", min: 1).get_members(key: "blah_at")).to eq %w(b c d)
+      end
+
+      it 'filters by max only' do
+        expect(described_class.new(keys: "blah_at", max: 2).get_members(key: "blah_at")).to eq %w(a)
+      end
+
+      it 'filters by min and max' do
+        expect(described_class.new(keys: "blah_at", min: 1, max: 4).get_members(key: "blah_at")).to eq %w(b c)
+      end
+
+      it 'limits' do
+        expect(described_class.new(keys: "blah_at", offset: 1, limit: 2)
+                              .get_members(key: "blah_at", use_limit_if_sorted_set: true)).to eq %w(b c)
+      end
+
+      it 'filters by min/max and limits' do
+        expect(described_class.new(keys: "blah_at", min: 1, max: 4, offset: 0, limit: 1)
+                              .get_members(key: "blah_at", use_limit_if_sorted_set: true)).to eq %w(b)
+      end
+    end
+
+    context 'unsorted set' do
+      before(:each) { Jobba.redis.sadd("blah", ["a", "b", "c"]) }
+
+      it 'returns all members' do
+        expect(described_class.new(keys: "blah").get_members(key: "blah")).to contain_exactly("a", "b", "c")
+      end
+    end
+  end
+
+  context '#result_ids and #result_count' do
+    before(:each) do
+      Jobba.redis.zadd("blah_at", [[1, "a"], [2, "b"], [3, "c"], [4, "d"]])
+      Jobba.redis.sadd("blah", ["c", "b", "a", "e"])
+    end
+
+    it 'works on one sorted set' do
+      clause = described_class.new(keys: "blah_at")
+      expect(clause.result_ids).to eq %w(a b c d)
+      expect(clause.result_count).to eq 4
+    end
+
+    it 'works on one unsorted set' do
+      clause = described_class.new(keys: "blah")
+      expect(clause.result_ids).to eq %w(a b c e)
+      expect(clause.result_count).to eq 4
+    end
+
+    it 'works on sorted and unsorted sets together' do
+      clause = described_class.new(keys: ["blah", "blah_at"])
+      expect(clause.result_ids).to eq %w(a b c d e)
+      expect(clause.result_count).to eq 5
+    end
+
+    it 'can limit on combo of sorted and unsorted' do
+      clause = described_class.new(keys: ["blah", "blah_at"], offset: 1, limit: 2)
+      expect(clause.result_ids).to eq %w(b c)
+      expect(clause.result_count).to eq 2
+    end
+
+    it 'ignores uniqueness concerns if we set keys_contain_only_unique_ids' do
+      clause = described_class.new(keys: ["blah", "blah_at"], keys_contain_only_unique_ids: true) # not really true
+      expect(clause.result_ids).to eq %w(a a b b c c d e)
+      expect(clause.result_count).to eq 8
+    end
+  end
+
+end

--- a/spec/clause_spec.rb
+++ b/spec/clause_spec.rb
@@ -8,19 +8,19 @@ describe Jobba::Clause do
 
       it 'filters by min only' do
         expect(
-          described_class.new(keys: "blah_at", min: 1).get_members(key: "blah_at")
+          described_class.new(keys: "blah_at", min: 2).get_members(key: "blah_at")
         ).to eq ({ids: %w(b c d), is_limited: false})
       end
 
       it 'filters by max only' do
         expect(
           described_class.new(keys: "blah_at", max: 2).get_members(key: "blah_at")
-        ).to eq ({ids: %w(a), is_limited: false})
+        ).to eq ({ids: %w(a b), is_limited: false})
       end
 
       it 'filters by min and max' do
         expect(
-          described_class.new(keys: "blah_at", min: 1, max: 4).get_members(key: "blah_at")
+          described_class.new(keys: "blah_at", min: 2, max: 3).get_members(key: "blah_at")
         ).to eq ({ids: %w(b c), is_limited: false})
       end
 
@@ -32,7 +32,7 @@ describe Jobba::Clause do
 
       it 'filters by min/max and limits' do
         expect(
-          described_class.new(keys: "blah_at", min: 1, max: 4).get_members(key: "blah_at", offset: 0, limit: 1)
+          described_class.new(keys: "blah_at", min: 2, max: 4).get_members(key: "blah_at", offset: 0, limit: 1)
         ).to eq ({ids: %w(b), is_limited: true})
       end
     end

--- a/spec/clause_spec.rb
+++ b/spec/clause_spec.rb
@@ -19,13 +19,13 @@ describe Jobba::Clause do
       end
 
       it 'limits' do
-        expect(described_class.new(keys: "blah_at", offset: 1, limit: 2)
-                              .get_members(key: "blah_at", use_limit_if_sorted_set: true)).to eq %w(b c)
+        expect(described_class.new(keys: "blah_at")
+                              .get_members(key: "blah_at", offset: 1, limit: 2)).to eq %w(b c)
       end
 
       it 'filters by min/max and limits' do
-        expect(described_class.new(keys: "blah_at", min: 1, max: 4, offset: 0, limit: 1)
-                              .get_members(key: "blah_at", use_limit_if_sorted_set: true)).to eq %w(b)
+        expect(described_class.new(keys: "blah_at", min: 1, max: 4)
+                              .get_members(key: "blah_at", offset: 0, limit: 1)).to eq %w(b)
       end
     end
 
@@ -63,9 +63,9 @@ describe Jobba::Clause do
     end
 
     it 'can limit on combo of sorted and unsorted' do
-      clause = described_class.new(keys: ["blah", "blah_at"], offset: 1, limit: 2)
-      expect(clause.result_ids).to eq %w(b c)
-      expect(clause.result_count).to eq 2
+      clause = described_class.new(keys: ["blah", "blah_at"])
+      expect(clause.result_ids(offset: 1, limit: 2)).to eq %w(b c)
+      expect(clause.result_count(offset: 1, limit: 2)).to eq 2
     end
 
     it 'ignores uniqueness concerns if we set keys_contain_only_unique_ids' do

--- a/spec/clause_spec.rb
+++ b/spec/clause_spec.rb
@@ -7,25 +7,33 @@ describe Jobba::Clause do
       before(:each) { Jobba.redis.zadd("blah_at", [[1, "a"], [2, "b"], [3, "c"], [4, "d"]]) }
 
       it 'filters by min only' do
-        expect(described_class.new(keys: "blah_at", min: 1).get_members(key: "blah_at")).to eq %w(b c d)
+        expect(
+          described_class.new(keys: "blah_at", min: 1).get_members(key: "blah_at")
+        ).to eq ({ids: %w(b c d), is_limited: false})
       end
 
       it 'filters by max only' do
-        expect(described_class.new(keys: "blah_at", max: 2).get_members(key: "blah_at")).to eq %w(a)
+        expect(
+          described_class.new(keys: "blah_at", max: 2).get_members(key: "blah_at")
+        ).to eq ({ids: %w(a), is_limited: false})
       end
 
       it 'filters by min and max' do
-        expect(described_class.new(keys: "blah_at", min: 1, max: 4).get_members(key: "blah_at")).to eq %w(b c)
+        expect(
+          described_class.new(keys: "blah_at", min: 1, max: 4).get_members(key: "blah_at")
+        ).to eq ({ids: %w(b c), is_limited: false})
       end
 
       it 'limits' do
-        expect(described_class.new(keys: "blah_at")
-                              .get_members(key: "blah_at", offset: 1, limit: 2)).to eq %w(b c)
+        expect(
+          described_class.new(keys: "blah_at").get_members(key: "blah_at", offset: 1, limit: 2)
+        ).to eq ({ids: %w(b c), is_limited: true})
       end
 
       it 'filters by min/max and limits' do
-        expect(described_class.new(keys: "blah_at", min: 1, max: 4)
-                              .get_members(key: "blah_at", offset: 0, limit: 1)).to eq %w(b)
+        expect(
+          described_class.new(keys: "blah_at", min: 1, max: 4).get_members(key: "blah_at", offset: 0, limit: 1)
+        ).to eq ({ids: %w(b), is_limited: true})
       end
     end
 
@@ -33,7 +41,7 @@ describe Jobba::Clause do
       before(:each) { Jobba.redis.sadd("blah", ["a", "b", "c"]) }
 
       it 'returns all members' do
-        expect(described_class.new(keys: "blah").get_members(key: "blah")).to contain_exactly("a", "b", "c")
+        expect(described_class.new(keys: "blah").get_members(key: "blah")[:ids]).to contain_exactly("a", "b", "c")
       end
     end
   end

--- a/spec/id_clause_spec.rb
+++ b/spec/id_clause_spec.rb
@@ -1,0 +1,25 @@
+require 'spec_helper'
+
+describe Jobba::IdClause do
+
+  context '#result_ids' do
+    it 'gets statuses when ids are strings' do
+      expect(described_class.new(['hi', 'there']).result_ids).to eq (['hi', 'there'])
+    end
+
+    it 'gets statuses when ids are symbols' do
+      expect(described_class.new([:hi, :there]).result_ids).to eq (['hi', 'there'])
+    end
+  end
+
+  context '#result_count' do
+    it 'works with 2 ids' do
+      expect(described_class.new(['hi', 'there']).result_count).to eq 2
+    end
+
+    it 'works with no ids' do
+      expect(described_class.new(nil).result_count).to eq 0
+    end
+  end
+
+end

--- a/spec/jobba_spec.rb
+++ b/spec/jobba_spec.rb
@@ -5,4 +5,13 @@ describe Jobba do
 
   it_behaves_like 'status'
 
+  it 'computes `all.count` efficiently' do
+    2.times { make_status(state: :unqueued) }
+    1.times { make_status(state: :succeeded) }
+    3.times { make_status(state: :started) }
+
+    expect(Jobba.redis).to receive(:scard).exactly(Jobba::State::ALL.count).times.and_call_original
+    expect(Jobba.all.count).to eq 6
+  end
+
 end

--- a/spec/load_spec.rb
+++ b/spec/load_spec.rb
@@ -1,0 +1,22 @@
+require 'spec_helper'
+
+# Run this on its own with `USE_REAL_REDIS=true rspec ./spec/load_spec.rb`
+xdescribe 'Load performance' do
+
+  before(:each) do
+    # This takes a long time.
+    t = Time.now
+    100.times{ |i|
+      puts "#{i}: #{Time.now - t}"
+      t = Time.now
+      10000.times { Jobba::Status.create! }
+    }
+  end
+
+  it 'runs Jobba.all.count quickly' do
+    t = Time.now
+    Jobba.all.count
+    expect(Time.now - t).to be < 1.0
+  end
+
+end

--- a/spec/query_spec.rb
+++ b/spec/query_spec.rb
@@ -50,7 +50,7 @@ RSpec.describe Jobba::Query do
     queued   = make_status(state: :queued, id: :queued_1)
     started  = make_status(state: :started, id: :started_1)
 
-    expect(Jobba.redis).not_to receive(:mget)
+    expect(Jobba.redis).not_to receive(:hgetall)
     expect(where(state: :started).count).to eq 1
   end
 

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -14,11 +14,11 @@ RSpec.configure do |config|
 
   if Jobba::Spec::Utils.use_real_redis?
     config.before(:suite) do
-      Jobba::Spec::Utils.clear_jobba_keys
+      Jobba.clear_all_jobba_data!
     end
 
     config.after(:each) do
-      Jobba::Spec::Utils.clear_jobba_keys
+      Jobba.clear_all_jobba_data!
     end
   end
 

--- a/spec/spec_utils.rb
+++ b/spec/spec_utils.rb
@@ -10,11 +10,6 @@ module Jobba
         ENV["USE_REAL_REDIS"] == "true"
       end
 
-      def self.clear_jobba_keys
-        keys = Jobba.redis.keys("*")
-        Jobba.redis.del(*keys) if keys.any?
-      end
-
     end
   end
 end

--- a/spec/utils_spec.rb
+++ b/spec/utils_spec.rb
@@ -32,5 +32,43 @@ describe Jobba::Utils do
     end
   end
 
+  describe '#limited_count' do
+
+    it 'does not limit when offset and limit are nil' do
+      expect(described_class.limited_count(nonlimited_count: 10, offset: nil, limit: nil)).to eq 10
+    end
+
+    it 'does not limit when offset and limit do not limit' do
+      expect(described_class.limited_count(nonlimited_count: 10, offset: 0, limit: 10)).to eq 10
+    end
+
+    it 'limits when limit causes us to run off the end' do
+      expect(described_class.limited_count(nonlimited_count: 10, offset: 9, limit: 2)).to eq 1
+    end
+
+    it 'works when limit and offset take us to the end exactly' do
+      expect(described_class.limited_count(nonlimited_count: 10, offset: 9, limit: 1)).to eq 1
+    end
+
+    it 'limits when offset starts us off the end' do
+      expect(described_class.limited_count(nonlimited_count: 10, offset: 11, limit: 42)).to eq 0
+      expect(described_class.limited_count(nonlimited_count: 10, offset: 10, limit: 0)).to eq 0
+    end
+
+    it 'limits when limit and offset do not run off the end' do
+      expect(described_class.limited_count(nonlimited_count: 10, offset: 2, limit: 5)).to eq 5
+    end
+
+    it 'limits when offset nil but limit set' do
+      expect(described_class.limited_count(nonlimited_count: 10, offset: nil, limit: 2)).to eq 2
+      expect(described_class.limited_count(nonlimited_count: 10, offset: nil, limit: 11)).to eq 10
+    end
+
+    it 'limits when offset set but limit nil' do
+      expect(described_class.limited_count(nonlimited_count: 10, offset: 7, limit: nil)).to eq 3
+      expect(described_class.limited_count(nonlimited_count: 10, offset: 10, limit: nil)).to eq 0
+    end
+  end
+
 
 end


### PR DESCRIPTION
Count operations, which you think would be fast because the corresponding redis ops are fast, were slow because Jobba always assumed we'd have chained queries.  As such, Jobba would do at least one `ZUNIONSTORE` to get a query clause into a temporary working set, which was slow when all we wanted to do was count things.

This PR adds efficiencies when there is only one `where` clause to use faster operations when possible.

Also adds pagination -- see the README changes.