### PR TITLE
Expire all Redis hashes and sets and make clear_all_jobba_data! not break prod

### DIFF
--- a/lib/jobba.rb
+++ b/lib/jobba.rb
@@ -38,14 +38,6 @@ module Jobba
     )
   end
 
-  # Clears the whole shebang!  USE WITH CARE!
-  def self.clear_all_jobba_data!
-    keys = Jobba.redis.keys("*")
-    keys.each_slice(1000) do |some_keys|
-      Jobba.redis.del(*some_keys)
-    end
-  end
-
   def self.cleanup(seconds_ago: 60*60*24*30*12, batch_size: 1000)
     start_time = Jobba::Time.now
     delete_before = start_time - seconds_ago
@@ -59,6 +51,12 @@ module Jobba
       jobs_count += num_jobs
       break if jobs.size < batch_size
     end
+    jobs_count
+  end
+
+  # Clears the whole shebang!  USE WITH CARE!
+  def self.clear_all_jobba_data!
+    cleanup(seconds_ago: 0)
   end
 
 end

--- a/lib/jobba.rb
+++ b/lib/jobba.rb
@@ -1,3 +1,4 @@
+require 'delegate'
 require 'forwardable'
 require 'securerandom'
 
@@ -10,6 +11,7 @@ require "jobba/time"
 require "jobba/utils"
 require "jobba/configuration"
 require "jobba/common"
+require "jobba/redis_with_expiration"
 require "jobba/state"
 require "jobba/status"
 require "jobba/statuses"
@@ -32,9 +34,11 @@ module Jobba
   end
 
   def self.redis
-    @redis ||= Redis::Namespace.new(
-      configuration.namespace,
-      redis: Redis.new(configuration.redis_options || {})
+    @redis ||= Jobba::RedisWithExpiration.new(
+      Redis::Namespace.new(
+        configuration.namespace,
+        redis: Redis.new(configuration.redis_options || {})
+      )
     )
   end
 

--- a/lib/jobba/redis_with_expiration.rb
+++ b/lib/jobba/redis_with_expiration.rb
@@ -1,13 +1,67 @@
-class Jobba::RedisWithExpiration < DelegateClass(Redis::Namespace)
+# This class provides Redis commands that automatically set key expiration.
+# The only commands modified are commands that:
+# 1. Take their (only) key as the first argument
+# AND
+# 2. Modify said key
+# AND
+# 3. Don't already set the key expiration by themselves
+class Jobba::RedisWithExpiration < SimpleDelegator
   # 68.years in seconds
   EXPIRES_IN = 2145916800
 
-  EXPIRE_METHODS = [ :hmset, :hset, :hsetnx, :sadd, :srem, :zadd, :zrem ]
+  EXPIRE_METHODS = [
+    :append,
+    :decr,
+    :decrby,
+    :hdel,
+    :hincrby,
+    :hincrbyfloat,
+    :hmset,
+    :hset,
+    :hsetnx,
+    :incr,
+    :incrby,
+    :incrbyfloat,
+    :linsert,
+    :lpop,
+    :lpush,
+    :lpushx,
+    :lrem,
+    :lset,
+    :ltrim,
+    :mapped_hmset,
+    :migrate,
+    :move,
+    :pfadd,
+    :pfmerge,
+    :restore,
+    :rpop,
+    :rpush,
+    :rpushx,
+    :sadd,
+    :set,
+    :setbit,
+    :setnx,
+    :setrange,
+    :sinterstore,
+    :smove,
+    :spop,
+    :srem,
+    :sunionstore,
+    :zadd,
+    :zincrby,
+    :zinterstore,
+    :zrem,
+    :zremrangebyrank,
+    :zremrangebyscore,
+    :zunionstore
+  ]
 
   EXPIRE_METHODS.each do |method|
-    define_method(method) do |key, *args|
-      result = super(key, *args)
-      expire(key, EXPIRES_IN) if result
+    define_method method do |key, *args|
+      result = super key, *args
+      # Only set expiration if the command (seems to have) succeeded
+      expire key, EXPIRES_IN if result
       result
     end
   end

--- a/lib/jobba/redis_with_expiration.rb
+++ b/lib/jobba/redis_with_expiration.rb
@@ -1,0 +1,14 @@
+class Jobba::RedisWithExpiration < DelegateClass(Redis::Namespace)
+  # 68.years in seconds
+  EXPIRES_IN = 2145916800
+
+  EXPIRE_METHODS = [ :hmset, :hset, :hsetnx, :sadd, :srem, :zadd, :zrem ]
+
+  EXPIRE_METHODS.each do |method|
+    define_method(method) do |key, *args|
+      result = super(key, *args)
+      expire(key, EXPIRES_IN) if result
+      result
+    end
+  end
+end

--- a/lib/jobba/version.rb
+++ b/lib/jobba/version.rb
@@ -1,3 +1,3 @@
 module Jobba
-  VERSION = "1.6.0"
+  VERSION = "1.6.1"
 end

--- a/spec/clause_spec.rb
+++ b/spec/clause_spec.rb
@@ -5,6 +5,7 @@ describe Jobba::Clause do
   context '#get_members' do
     context 'sorted set' do
       before(:each) { Jobba.redis.zadd("blah_at", [[1, "a"], [2, "b"], [3, "c"], [4, "d"]]) }
+      after(:each)  { Jobba.redis.del("blah_at") }
 
       it 'filters by min only' do
         expect(
@@ -50,6 +51,10 @@ describe Jobba::Clause do
     before(:each) do
       Jobba.redis.zadd("blah_at", [[1, "a"], [2, "b"], [3, "c"], [4, "d"]])
       Jobba.redis.sadd("blah", ["c", "b", "a", "e"])
+    end
+    after(:each)  do
+      Jobba.redis.del("blah_at")
+      Jobba.redis.del("blah")
     end
 
     it 'works on one sorted set' do

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -13,15 +13,13 @@ RSpec.configure do |config|
   config.include Helpers
 
   if Jobba::Spec::Utils.use_real_redis?
-    config.before(:suite) do
+    config.before(:each) do
       Jobba.clear_all_jobba_data!
     end
 
-    config.after(:each) do
+    config.after(:suite) do
       Jobba.clear_all_jobba_data!
     end
   end
 
 end
-
-


### PR DESCRIPTION
Running the cleanup method is still needed, because Redis can only expire the entire hash/set at once, not individual keys/values.

When reviewing, keep in mind that keys with expiration can be evicted at any point in time, so try to think if any of these could cause errors if evicted at bad moments.

This PR also makes `clear_all_jobba_data!` use the cleanup method, since the current implementation of `clear_all_jobba_data!` uses `KEYS *` which fails with a timeout for large datasets.