### PR TITLE
Fix bug with redis 4, update versions

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -32,7 +32,7 @@ jobs:
           # Maps port 6379 on service container to the host
           - 6379:6379
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
       - uses: ruby/setup-ruby@v1
         with:
           ruby-version: ${{ matrix.ruby }}

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -12,12 +12,12 @@ on:
 jobs:
   tests:
     timeout-minutes: 30
-    runs-on: ubuntu-18.04
+    runs-on: ubuntu-22.04
     strategy:
       fail-fast: false
       matrix:
         os: [ubuntu]
-        ruby: [ '2.5', '2.6', '2.7' ]
+        ruby: [ '2.6', '2.7', '3.0', '3.1' ]
     services:
       # Label used to access the service container
       redis:

--- a/jobba.gemspec
+++ b/jobba.gemspec
@@ -1,30 +1,29 @@
-# coding: utf-8
-lib = File.expand_path('../lib', __FILE__)
+lib = File.expand_path('lib', __dir__)
 $LOAD_PATH.unshift(lib) unless $LOAD_PATH.include?(lib)
 require 'jobba/version'
 
 Gem::Specification.new do |spec|
-  spec.name          = "jobba"
+  spec.name          = 'jobba'
   spec.version       = Jobba::VERSION
-  spec.authors       = ["JP Slavinsky"]
-  spec.email         = ["jps@kindlinglabs.com"]
+  spec.authors       = ['JP Slavinsky']
+  spec.email         = ['jps@kindlinglabs.com']
 
-  spec.summary       = %q{Redis-based background job status tracking.}
-  spec.description   = %q{Redis-based background job status tracking.}
-  spec.homepage      = "https://github.com/openstax/jobba"
-  spec.license       = "MIT"
+  spec.summary       = 'Redis-based background job status tracking.'
+  spec.description   = 'Redis-based background job status tracking.'
+  spec.homepage      = 'https://github.com/openstax/jobba'
+  spec.license       = 'MIT'
 
   spec.files         = `git ls-files -z`.split("\x0").reject { |f| f.match(%r{^(test|spec|features)/}) }
-  spec.bindir        = "exe"
+  spec.bindir        = 'exe'
   spec.executables   = spec.files.grep(%r{^exe/}) { |f| File.basename(f) }
-  spec.require_paths = ["lib"]
+  spec.require_paths = ['lib']
 
-  spec.add_runtime_dependency "redis"
-  spec.add_runtime_dependency "oj"
-  spec.add_runtime_dependency "redis-namespace"
+  spec.add_runtime_dependency 'oj'
+  spec.add_runtime_dependency 'redis', '>= 4.0'
+  spec.add_runtime_dependency 'redis-namespace'
 
-  spec.add_development_dependency "rake"
-  spec.add_development_dependency "rspec"
-  spec.add_development_dependency "byebug"
-  spec.add_development_dependency "fakeredis"
+  spec.add_development_dependency 'byebug'
+  spec.add_development_dependency 'fakeredis'
+  spec.add_development_dependency 'rake'
+  spec.add_development_dependency 'rspec'
 end

--- a/lib/jobba/common.rb
+++ b/lib/jobba/common.rb
@@ -1,7 +1,10 @@
 module Jobba::Common
-
   def redis
     Jobba.redis
+  end
+
+  def transaction(&block)
+    Jobba.transaction(&block)
   end
 
   module ClassMethods
@@ -13,5 +16,4 @@ module Jobba::Common
   def self.included(base)
     base.extend(ClassMethods)
   end
-
 end

--- a/lib/jobba/status.rb
+++ b/lib/jobba/status.rb
@@ -25,7 +25,7 @@ module Jobba
     # exists in the store, returns a job with 'unknown' state and sets it
     # in the store
     def self.find!(id)
-      find(id) || create(id:)
+      find(id) || create(id: id)
     end
 
     # Finds the job with the specified ID and returns it.  If no such ID
@@ -111,7 +111,7 @@ module Jobba
 
     def set_progress(at, out_of = nil)
       progress = compute_fractional_progress(at, out_of)
-      set(progress:)
+      set(progress: progress)
     end
 
     def set_job_name(job_name)
@@ -120,7 +120,7 @@ module Jobba
 
       transaction do |trn|
         trn.srem(job_name_key, id)
-        set(job_name:)
+        set(job_name: job_name)
         trn.sadd(job_name_key, id)
       end
     end
@@ -147,7 +147,7 @@ module Jobba
 
       transaction do |trn|
         trn.srem(provider_job_id_key, id)
-        set(provider_job_id:)
+        set(provider_job_id: provider_job_id)
         trn.sadd(provider_job_id_key, id)
       end
     end
@@ -156,7 +156,7 @@ module Jobba
       raise ArgumentError, 'The argument to `add_error` cannot be nil', caller if error.nil?
 
       errors.push(normalize_for_json(error))
-      set(errors:)
+      set(errors: errors)
     end
 
     def save(data)
@@ -206,15 +206,15 @@ module Jobba
       # set the restarted values
 
       restarted_values = {
-        id:,
+        id: id,
         attempt: attempt + 1,
-        recorded_at:,
-        queued_at:,
+        recorded_at: recorded_at,
+        queued_at: queued_at,
         progress: 0,
         errors: [],
-        job_name:,
-        job_args:,
-        provider_job_id:
+        job_name: job_name,
+        job_args: job_args,
+        provider_job_id: provider_job_id,
       }
 
       archive_attempt!
@@ -231,7 +231,7 @@ module Jobba
     end
 
     def move_to_state!(state)
-      set(state:, state.timestamp_name_key => Jobba::Time.now)
+      set(state: state, state.timestamp_name_key => Jobba::Time.now)
     end
 
     def initialize(attrs = {})
@@ -255,10 +255,10 @@ module Jobba
 
       transaction do
         set(
-          id:,
-          progress:,
-          errors:,
-          attempt:
+          id: id,
+          progress: progress,
+          errors: errors,
+          attempt: attempt
         )
         move_to_state!(state)
       end

--- a/lib/jobba/status.rb
+++ b/lib/jobba/status.rb
@@ -3,7 +3,6 @@ require 'oj'
 
 module Jobba
   class Status
-
     include Jobba::Common
 
     def self.all
@@ -26,7 +25,7 @@ module Jobba
     # exists in the store, returns a job with 'unknown' state and sets it
     # in the store
     def self.find!(id)
-      find(id) || create(id: id)
+      find(id) || create(id:)
     end
 
     # Finds the job with the specified ID and returns it.  If no such ID
@@ -40,8 +39,8 @@ module Jobba
     end
 
     def self.local_attrs
-      %w(id state progress errors data kill_requested_at
-        job_name job_args provider_job_id attempt prior_attempts) +
+      %w[id state progress errors data kill_requested_at
+         job_name job_args provider_job_id attempt prior_attempts] +
         State::ALL.collect(&:timestamp_name)
     end
 
@@ -56,7 +55,7 @@ module Jobba
     # As an extra step, convert state names into State objects.
 
     local_attrs.each do |attribute|
-      class_eval <<-eoruby
+      class_eval <<-EORUBY, __FILE__, __LINE__ + 1
         def #{attribute}
           @#{attribute} ||= load_from_json_encoded_attrs('#{attribute}')
         end
@@ -64,12 +63,12 @@ module Jobba
         protected
 
         attr_writer :#{attribute}
-      eoruby
+      EORUBY
     end
 
     State::ENTERABLE.each do |state|
       define_method("#{state.name}!") do
-        redis.multi do
+        transaction do
           if state == State::STARTED && did_start?
             restart!
           elsif state != self.state
@@ -96,14 +95,14 @@ module Jobba
     end
 
     def did_start?
-      !self.started_at.nil?
+      !started_at.nil?
     end
 
     def request_kill!
       time, usec_int = now
-      if redis.hsetnx(job_key, :kill_requested_at, usec_int)
-        @kill_requested_at = time
-      end
+      return unless redis.hsetnx(job_key, :kill_requested_at, usec_int)
+
+      @kill_requested_at = time
     end
 
     def kill_requested?
@@ -112,28 +111,30 @@ module Jobba
 
     def set_progress(at, out_of = nil)
       progress = compute_fractional_progress(at, out_of)
-      set(progress: progress)
+      set(progress:)
     end
 
     def set_job_name(job_name)
-      raise ArgumentError, "`job_name` must not be blank", caller \
+      raise ArgumentError, '`job_name` must not be blank', caller \
         if job_name.nil? || job_name.empty?
 
-      redis.multi do
-        redis.srem(job_name_key, id)
-        set(job_name: job_name)
-        redis.sadd(job_name_key, id)
+      transaction do |trn|
+        trn.srem(job_name_key, id)
+        set(job_name:)
+        trn.sadd(job_name_key, id)
       end
     end
 
-    def set_job_args(args_hash={})
-      raise ArgumentError,
-            "All values in the hash passed to `set_job_args` must be strings",
-            caller if args_hash.values.any?{|val| !val.is_a?(String)}
+    def set_job_args(args_hash = {})
+      if args_hash.values.any? { |val| !val.is_a?(String) }
+        raise ArgumentError,
+              'All values in the hash passed to `set_job_args` must be strings',
+              caller
+      end
 
       args_hash = normalize_for_json(args_hash)
 
-      redis.multi do
+      transaction do
         delete_self_from_job_args_set!
         set(job_args: args_hash)
         add_self_to_job_args_set!
@@ -141,21 +142,21 @@ module Jobba
     end
 
     def set_provider_job_id(provider_job_id)
-      raise ArgumentError, "`provider_job_id` must not be blank", caller \
+      raise ArgumentError, '`provider_job_id` must not be blank', caller \
         if provider_job_id.nil? || (provider_job_id.respond_to?(:empty?) && provider_job_id.empty?)
 
-      redis.multi do
-        redis.srem(provider_job_id_key, id)
-        set(provider_job_id: provider_job_id)
-        redis.sadd(provider_job_id_key, id)
+      transaction do |trn|
+        trn.srem(provider_job_id_key, id)
+        set(provider_job_id:)
+        trn.sadd(provider_job_id_key, id)
       end
     end
 
     def add_error(error)
-      raise ArgumentError, "The argument to `add_error` cannot be nil", caller if error.nil?
+      raise ArgumentError, 'The argument to `add_error` cannot be nil', caller if error.nil?
 
       errors.push(normalize_for_json(error))
-      set(errors: errors)
+      set(errors:)
     end
 
     def save(data)
@@ -171,11 +172,13 @@ module Jobba
     end
 
     def delete
-      completed? ?
-        delete! :
-        raise(NotCompletedError, "This status cannot be deleted because it " \
-                                 "isn't complete.  Use `delete!` if you want to " \
-                                 "delete anyway.")
+      if completed?
+        delete!
+      else
+        raise(NotCompletedError, 'This status cannot be deleted because it ' \
+                                       "isn't complete.  Use `delete!` if you want to " \
+                                       'delete anyway.')
+      end
     end
 
     def delete!
@@ -184,7 +187,7 @@ module Jobba
     end
 
     def prior_attempts
-      @prior_attempts ||= [*0..attempt-1].collect{|ii| self.class.find!("#{id}:#{ii}")}
+      @prior_attempts ||= [*0..attempt - 1].collect { |ii| self.class.find!("#{id}:#{ii}") }
     end
 
     protected
@@ -203,15 +206,15 @@ module Jobba
       # set the restarted values
 
       restarted_values = {
-        id: id,
-        attempt: attempt+1,
-        recorded_at: recorded_at,
-        queued_at: queued_at,
+        id:,
+        attempt: attempt + 1,
+        recorded_at:,
+        queued_at:,
         progress: 0,
         errors: [],
-        job_name: job_name,
-        job_args: job_args,
-        provider_job_id: provider_job_id
+        job_name:,
+        job_args:,
+        provider_job_id:
       }
 
       archive_attempt!
@@ -228,7 +231,7 @@ module Jobba
     end
 
     def move_to_state!(state)
-      set(state: state, state.timestamp_name_key => Jobba::Time.now)
+      set(state:, state.timestamp_name_key => Jobba::Time.now)
     end
 
     def initialize(attrs = {})
@@ -236,29 +239,28 @@ module Jobba
 
       @json_encoded_attrs = attrs[:raw]
 
-      if @json_encoded_attrs.nil? || @json_encoded_attrs.empty?
+      return unless @json_encoded_attrs.nil? || @json_encoded_attrs.empty?
 
-        @id       = attrs[:id]       || SecureRandom.uuid
-        @state    = attrs[:state]    || State::UNKNOWN
-        @progress = attrs[:progress] || 0
-        @errors   = attrs[:errors]   || []
-        @data     = attrs[:data]
-        @attempt  = attrs[:attempt]  || 0
-        @job_args = attrs[:job_args] || {}
-        @job_name = attrs[:job_name]
-        @provider_job_id = attrs[:provider_job_id]
+      @id       = attrs[:id]       || SecureRandom.uuid
+      @state    = attrs[:state]    || State::UNKNOWN
+      @progress = attrs[:progress] || 0
+      @errors   = attrs[:errors]   || []
+      @data     = attrs[:data]
+      @attempt  = attrs[:attempt]  || 0
+      @job_args = attrs[:job_args] || {}
+      @job_name = attrs[:job_name]
+      @provider_job_id = attrs[:provider_job_id]
 
-        if attrs[:persist]
-          redis.multi do
-            set(
-              id: id,
-              progress: progress,
-              errors: errors,
-              attempt: attempt
-            )
-            move_to_state!(state)
-          end
-        end
+      return unless attrs[:persist]
+
+      transaction do
+        set(
+          id:,
+          progress:,
+          errors:,
+          attempt:
+        )
+        move_to_state!(state)
       end
     end
 
@@ -310,6 +312,7 @@ module Jobba
 
     def set_state_in_redis(hash)
       return unless hash[:state]
+
       redis.srem(state.name, id) unless state.nil? # leave old state if set
       redis.sadd(hash[:state].name, id)            # enter new state
     end
@@ -324,11 +327,11 @@ module Jobba
     end
 
     def set_hash_locally(hash)
-      hash.each{ |key, value| self.send("#{key}=", value) }
+      hash.each { |key, value| send("#{key}=", value) }
     end
 
     def delete_in_redis!
-      redis.multi do
+      transaction do
         redis.del(job_key)
 
         State::ALL.each do |state|
@@ -353,31 +356,32 @@ module Jobba
     end
 
     def delete_self_from_job_args_set!
-      self.job_args.values.each do |arg|
+      job_args.values.each do |arg|
         redis.srem(job_arg_key(arg), id)
       end
     end
 
     def add_self_to_job_args_set!
-      self.job_args.values.each do |arg|
+      job_args.values.each do |arg|
         redis.sadd(job_arg_key(arg), id)
       end
     end
 
     def clear_attrs
-      self.class.local_attrs.each{|aa| send("#{aa}=",nil)}
+      self.class.local_attrs.each { |aa| send("#{aa}=", nil) }
     end
 
     def job_name_key
       "job_name:#{job_name}"
     end
 
-    def job_key(attempt=nil)
+    def job_key(attempt = nil)
       self.class.job_key(id, attempt)
     end
 
-    def self.job_key(id, attempt=nil)
-      raise ArgumentError, "`id` cannot be nil", caller if id.nil?
+    def self.job_key(id, attempt = nil)
+      raise ArgumentError, '`id` cannot be nil', caller if id.nil?
+
       attempt.nil? ? "id:#{id}" : "id:#{id}:#{attempt}"
     end
 
@@ -390,20 +394,21 @@ module Jobba
     end
 
     def job_errors_key(id)
-      raise ArgumentError, "`id` cannot be nil", caller if id.nil?
+      raise ArgumentError, '`id` cannot be nil', caller if id.nil?
+
       "#{id}:errors"
     end
 
     def compute_fractional_progress(at, out_of)
       if at.nil?
-        raise ArgumentError, "Must specify at least `at` argument to `progress` call", caller
+        raise ArgumentError, 'Must specify at least `at` argument to `progress` call', caller
       elsif at < 0
         raise ArgumentError, "progress cannot be negative (at=#{at})", caller
       elsif out_of && out_of < at
-        raise ArgumentError, "`out_of` must be greater than `at` in `progress` calls", caller
+        raise ArgumentError, '`out_of` must be greater than `at` in `progress` calls', caller
       elsif out_of.nil? && (at < 0 || at > 1)
         raise ArgumentError,
-              "If `out_of` not specified, `at` must be in the range [0.0, 1.0]",
+              'If `out_of` not specified, `at` must be in the range [0.0, 1.0]',
               caller
       end
 
@@ -413,6 +418,5 @@ module Jobba
     def now
       [time = Jobba::Time.now, Utils.time_to_usec_int(time)]
     end
-
   end
 end

--- a/lib/jobba/statuses.rb
+++ b/lib/jobba/statuses.rb
@@ -67,9 +67,9 @@ class Jobba::Statuses
   def get_all!
     id_keys = @ids.collect { |id| "id:#{id}" }
 
-    raw_statuses = redis.pipelined do
+    raw_statuses = redis.pipelined do |pipe|
       id_keys.each do |key|
-        hgetall(key)
+        pipe.hgetall(key)
       end
     end
 

--- a/lib/jobba/version.rb
+++ b/lib/jobba/version.rb
@@ -1,3 +1,3 @@
 module Jobba
-  VERSION = "1.8.1"
+  VERSION = '2.0.0'
 end


### PR DESCRIPTION
Redis pipeline commands need to be called using the pipeline instance and not the global redis one

Also fixes a redis 4 incompatibility with nesting `multi` calls